### PR TITLE
Fixed the issue #12

### DIFF
--- a/v1sim/network.py
+++ b/v1sim/network.py
@@ -32,10 +32,10 @@ class RfVLan(RfResource):
     pass
 
 
-class RfNetworkAdapterCollection(RfCollection):
+class RfNetworkInterfaceCollection(RfCollection):
     def element_type(self):
-        return RfNetworkAdapter
+        return RfNetworkInterface
 
 
-class RfNetworkAdapter(RfResource):
+class RfNetworkInterface(RfResource):
     pass

--- a/v1sim/systems.py
+++ b/v1sim/systems.py
@@ -5,7 +5,7 @@
 import os
 
 from .common_services import RfLogServiceCollection
-from .network import RfEthernetCollection, RfNetworkAdapterCollection
+from .network import RfEthernetCollection, RfNetworkInterfaceCollection
 from .resource import RfResource, RfCollection
 from .storage import RfSimpleStorageCollection, RfSmartStorage
 
@@ -20,7 +20,7 @@ class RfSystemObj(RfResource):
         resource_path = os.path.join(base_path, rel_path)
         contents = os.listdir(resource_path)
         for item in contents:
-            if item == "bios":
+            if item == "Bios":
                 self.components[item] = RfBios(base_path, os.path.join(rel_path, item), parent=self)
             elif item == "EthernetInterfaces":
                 self.components[item] = RfEthernetCollection(base_path, os.path.join(rel_path, item), parent=self)
@@ -36,10 +36,10 @@ class RfSystemObj(RfResource):
                 self.components[item] = RfSmartStorage(base_path, os.path.join(rel_path, item), parent=self)
             elif item == "SecureBoot":
                 self.components[item] = RfSecureBoot(base_path, os.path.join(rel_path, item), parent=self)
-            elif item == "NetworkAdapters":
-                self.components[item] = RfNetworkAdapterCollection(base_path, os.path.join(rel_path, item), parent=self)
-            elif item == "PCIDevices":
-                self.components[item] = RfPCIDeviceCollection(base_path, os.path.join(rel_path, item), parent=self)
+            elif item == "NetworkInterfaces":
+                self.components[item] = RfNetworkInterfaceCollection(base_path, os.path.join(rel_path, item), parent=self)
+            elif item == "PCIeDevices":
+                self.components[item] = RfPCIeDeviceCollection(base_path, os.path.join(rel_path, item), parent=self)
             elif item == "PCISlots":
                 self.components[item] = RfPCISlotCollection(base_path, os.path.join(rel_path, item), parent=self)
             elif item == "FirmwareInventory":
@@ -154,12 +154,12 @@ class RfBiosSettings(RfResource):
         return 0, 204, None, None
 
 
-class RfPCIDeviceCollection(RfCollection):
+class RfPCIeDeviceCollection(RfCollection):
     def element_type(self):
-        return RfPCIDevice
+        return RfPCIeDevice
 
 
-class RfPCIDevice(RfResource):
+class RfPCIeDevice(RfResource):
     pass
 
 


### PR DESCRIPTION
Fixed the issue #12

Redfish-Profile-Simulator\v1sim\systems.py is used to walk through the mockup folders under Systems in order to get the json files.

Some strings does not match the properties under ComputerSystem in ComputerSystem.json: “bios” should be “Bios”, NetworkAdapters should be “NetworkInterfaces “,”PCIDevices” should be “PCIeDevices”.