### PR TITLE
Create session (POST) should respond with 201

### DIFF
--- a/v1sim/redfishURIs.py
+++ b/v1sim/redfishURIs.py
@@ -223,7 +223,7 @@ def rfApi_SimpleServer(root, versions, host="127.0.0.1", port=5000):
             print("resp:{}".format(resp))
             hdr = {"X-Auth-Token": "123456SESSIONauthcode",
                    "Location": "/redfish/v1/SessionService/Sessions/SESSION123456"}
-            return resp, 200, hdr
+            return resp, 201, hdr
         else:
             return "", 401
 


### PR DESCRIPTION
When creating a session (POST to Sessions collection), the simulator responds with a 200 OK. Should respond with 201 Created. Fixed the response status.

Fixes #22  